### PR TITLE
[markdown] Use older version of mdl (0.9)

### DIFF
--- a/markdownlint/Dockerfile
+++ b/markdownlint/Dockerfile
@@ -5,7 +5,7 @@ RUN dnf -y --nodocs  --setopt=install_weak_deps=False \
 --disablerepo=fedora-modular \
 --disablerepo=updates-modular \
 install ruby rubygems git; \
-gem install mdl
+gem install "mdl:0.9"
 
 COPY action.sh /action/action.sh
 ENTRYPOINT ["bash", "/action/action.sh"]


### PR DESCRIPTION
https://github.com/markdownlint/markdownlint/issues/341

Signed-off-by: Martin Bašti <mbasti@redhat.com>