### PR TITLE
Update images to Fedora 34

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,16 +8,16 @@ Current collection:
 
 - flake8
   - docker
-  - Fedora: 32
+  - Fedora: 34
   - Py: 3
   - config: defaults, with "--max-line-length=100"
 - markdownlint (ruby)
   - docker
-  - Fedora: 32
+  - Fedora: 34
   - ruby: Fedora latest
   - config: currently per-repo
 - shellcheck: Only enabled for 'test.sh'
   - docker
-  - Fedora: 32
+  - Fedora: 34
   - shellcheck: Fedora latest
   - config: defaults

--- a/flake8/Dockerfile
+++ b/flake8/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:32
+FROM registry.fedoraproject.org/fedora:34
 
 RUN dnf -y --nodocs  --setopt=install_weak_deps=False \
 --disablerepo=fedora-cisco-openh264 \

--- a/markdownlint/Dockerfile
+++ b/markdownlint/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:32
+FROM registry.fedoraproject.org/fedora:34
 
 RUN dnf -y --nodocs  --setopt=install_weak_deps=False \
 --disablerepo=fedora-cisco-openh264 \

--- a/shellcheck/Dockerfile
+++ b/shellcheck/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:32
+FROM registry.fedoraproject.org/fedora:34
 
 RUN dnf -y --nodocs  --setopt=install_weak_deps=False \
 --disablerepo=fedora-cisco-openh264 \


### PR DESCRIPTION
The flake8 version available in Fedora 32 cannot handle the walrus
operator introduced in Python 3.8. Upgrade the flake8 image to Fedora 34
to get a more up to date version.

Update the other images as well to keep consistency.

Also specify that the images should come from registry.fedoraproject.org

Signed-off-by: Adam Cmiel <acmiel@redhat.com>