### PR TITLE
Add IBM/tekton-lint action

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,5 +22,12 @@ Current collection:
   - Fedora: 34
   - shellcheck: Fedora latest
   - config: defaults; only enabled for 'test.sh'
+- [tekton-lint][] (nodejs)
+  - docker
+  - Fedora: 34
+  - node >12 (uses Fedora latest, currently >14)
+  - tekton-lint@v0.6.0
+  - config: defaults; restricted to tekton yaml only
 
 [markdownlint]: https://github.com/markdownlint/markdownlint
+[tekton-lint]: https://github.com/IBM/tekton-lint

--- a/tekton-lint/Dockerfile
+++ b/tekton-lint/Dockerfile
@@ -1,0 +1,10 @@
+FROM fedora:34
+
+RUN dnf -y --nodocs  --setopt=install_weak_deps=False \
+--disablerepo=fedora-cisco-openh264 \
+--disablerepo=fedora-modular \
+--disablerepo=updates-modular \
+install nodejs npm; \
+npm install -g tekton-lint@v0.6.0
+
+ENTRYPOINT ["tekton-lint"]

--- a/tekton-lint/README.md
+++ b/tekton-lint/README.md
@@ -1,0 +1,5 @@
+# About
+
+A GitHub action to lint Tekton resource definitions (yaml files), using [IBM/tekton-lint][].
+
+[IBM/tekton-lint]: https://github.com/IBM/tekton-lint

--- a/tekton-lint/action.yaml
+++ b/tekton-lint/action.yaml
@@ -1,0 +1,16 @@
+name: "tekton-lint"
+author: "Ben Alkov <ben.alkov@redhat.com>"
+description: "GitHub action for tekton-lint."
+inputs:
+  path:
+    description: 'Path to Tekton resource definition yaml files'
+    required: true
+    default: 'tekton/**/*.yaml'
+runs:
+  using: 'docker'
+  image: 'Dockerfile'
+  args:
+    - ${{ inputs.path }}
+branding:
+  icon: 'terminal'
+  color: 'red'


### PR DESCRIPTION
Also, tested in https://github.com/ben-alkov/atomic-reactor/pull/15

It's easier to see how it works by looking at the following, rather than fishing around in that PR

- [FAIL][]; note that there is an 'error'
- [PASS][]; note that there *are* 'warnings' (you'll have to unfold the "Run tekton-lint" section), but the check passes

Signed-off-by: Ben Alkov <ben.alkov@redhat.com>

[FAIL]: https://github.com/ben-alkov/atomic-reactor/runs/4013959427?check_suite_focus=true#logs
[PASS]: https://github.com/ben-alkov/atomic-reactor/runs/4013873065?check_suite_focus=true#logs