### PR TITLE
Bump markdownlint to 0.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Current collection:
   - docker
   - Fedora: 34
   - ruby: Fedora latest
-  - mdl:0.9
+  - mdl:'>=0.11.0'
   - config: currently per-repo
 - shellcheck
   - docker

--- a/markdownlint/Dockerfile
+++ b/markdownlint/Dockerfile
@@ -6,7 +6,7 @@ RUN dnf -y --nodocs  --setopt=install_weak_deps=False \
 --disablerepo=updates-modular \
 install ruby rubygems git && \
 dnf clean all && \
-gem install "mdl:0.9"
+gem install mdl:'>=0.11.0'
 
 COPY action.sh /action/action.sh
 ENTRYPOINT ["bash", "/action/action.sh"]


### PR DESCRIPTION
0.11 fixed the bug which caused us to pin to 0.9

Signed-off-by: Ben Alkov <ben.alkov@redhat.com>