### PR TITLE
Parameterize shellcheck action...

### DIFF
--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -34,6 +34,19 @@ jobs:
       - name: Lint Dockerfiles with hadolint
         run: hadolint --ignore DL3013 --ignore DL3041 **/Dockerfile
 
+  shellcheck:
+    name: Shellcheck
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@v2
+
+      - name: Run ShellCheck
+        uses: containerbuildsystem/actions/shellcheck@master
+        with:
+          path: '.'
+
   yamllint:
     name: yamllint
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -34,7 +34,9 @@ Current collection
   - Fedora 35
   - ShellCheck, Fedora default (0.7.x)
   - called from 'action.sh'
-  - config: defaults; only enabled for 'test.sh'
+  - config: defaults
+  - inputs
+    - 'path' parameter, defaults to 'test.sh'
 - [tekton-lint][] (nodejs)
   - docker
   - Fedora 35

--- a/shellcheck/README.md
+++ b/shellcheck/README.md
@@ -4,7 +4,7 @@ A GitHub action to lint shell scripts using [ShellCheck][].
 
 ## Inputs
 
-### None; uses default config
+### Path to files to check, default config otherwise
 
 ## Outputs
 
@@ -12,6 +12,10 @@ A GitHub action to lint shell scripts using [ShellCheck][].
 
 ## Example usage
 
-`uses: containerbuildsystem/actions/shellcheck@master`
+```yaml
+   uses: containerbuildsystem/actions/shellcheck@master
+   with:
+     path: '.'
+```
 
 [ShellCheck]: https://github.com/koalaman/shellcheck

--- a/shellcheck/action.sh
+++ b/shellcheck/action.sh
@@ -1,23 +1,27 @@
 #!/usr/bin/env bash
 
+if [ $# -eq 0 ]
+  then
+    echo "Path to check is *REQUIRED*"
+    exit 1
+fi
+
 cd "$GITHUB_WORKSPACE" || exit 1
 
 declare exitstatus
 exitstatus=0
+path=$1
 
-# Uncomment everything below to check all shell scripts
-
-# declare -a filepaths
-# excludes+=( ! -path *./.git* )
-
-# readarray filepaths < <( find . -type f "${excludes[@]}" -exec file '{}' + \
-#                          | grep "shell script" \
-#                          | cut -d : -f 1 )
-
-# for file in "${filepaths[@]}"; do
-#    file_="${file//[$'\t\r\n ']}"
-    printf "\n:: shellchecking 'test.sh' ::"
-    shellcheck -Calways ./test.sh || exitstatus=$?
-# done
+# Check all shell scripts
+declare -a filepaths
+excludes+=( ! -path *./.git* )
+readarray filepaths < <( find "$path" -type f "${excludes[@]}" -exec file '{}' + \
+                         | grep "shell script" \
+                         | cut -d : -f 1 )
+for file in "${filepaths[@]}"; do
+   file_="${file//[$'\t\r\n ']}"
+    printf "\n:: shellchecking '%s' ::" "$file_"
+    shellcheck -Calways "$file_" || exitstatus=$?
+done
 
 exit "$exitstatus"

--- a/shellcheck/action.yaml
+++ b/shellcheck/action.yaml
@@ -2,9 +2,19 @@
 name: "shellcheck"
 author: "Ben Alkov <ben.alkov@redhat.com>"
 description: "GitHub action for ShellCheck."
+inputs:
+  path:
+    description: "Path to shell scripts to check. Can be a single file,
+                  wildcard, etc.
+                  '.' is recommended for `find`ing all shell scripts in the
+                  current repo."
+    required: true
+    default: './test.sh'
 runs:
   using: 'docker'
   image: 'Dockerfile'
+  args:
+    - ${{ inputs.path }}
 branding:
   icon: 'terminal'
   color: 'red'


### PR DESCRIPTION
...so that  we can check scripts in *this* repo

✅  [Test run][] in my repo

Note that the shellcheck run in *this* PR will fail, as it still points at 'containerbuildsystem/actions@master'

Signed-off-by: Ben Alkov <ben.alkov@redhat.com>

[Test run]: https://github.com/ben-alkov/actions/actions/runs/1422002175