### PR TITLE
Add yamllint action

### DIFF
--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -1,6 +1,6 @@
 name: Linters
 
-on:
+on:  # yamllint disable-line rule:truthy
   pull_request:
 
   push:
@@ -32,3 +32,14 @@ jobs:
 
       - name: Lint Dockerfiles with hadolint
         run: hadolint --ignore DL3013 --ignore DL3041 **/Dockerfile
+
+  yamllint:
+    name: yamllint
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@v2
+
+      - name: Run yamllint
+        uses: containerbuildsystem/actions/yamllint@master

--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -1,3 +1,4 @@
+---
 name: Linters
 
 on:  # yamllint disable-line rule:truthy

--- a/README.md
+++ b/README.md
@@ -42,9 +42,18 @@ Current collection
   - npm:
     - tekton-lint@v0.6.0
   - config: defaults; restricted to tekton yaml only
+- [yamllint][]
+  - docker
+  - Fedora 35
+  - Py 3, Fedora default (3.10.x)
+  - yamllint, Fedora default (1.26.x)
+  - config:
+    - '-s' strict mode, warnings are reported as errors
+    - 'path' parameter, all YAML by default
 
 [ansible-lint]: ./ansible-lint/README.md
 [flake8]: ./flake8/README.md
 [markdownlint]: ./markdownlint/README.md
 [ShellCheck]: ./shellcheck/README.md
 [tekton-lint]: ./tekton-lint/README.md
+[yamllint]: ./yamllint/README.md

--- a/ansible-lint/action.yaml
+++ b/ansible-lint/action.yaml
@@ -1,3 +1,4 @@
+---
 name: "ansible-lint"
 author: "Ben Alkov <ben.alkov@redhat.com>"
 description: "GitHub action for ansible-lint."

--- a/flake8/action.yaml
+++ b/flake8/action.yaml
@@ -1,3 +1,4 @@
+---
 name: "flake8 for Py3"
 author: "Ben Alkov <ben.alkov@redhat.com>"
 description: "GitHub action for flake8 using Python 3."

--- a/markdownlint/action.yaml
+++ b/markdownlint/action.yaml
@@ -1,3 +1,4 @@
+---
 name: "markdownlint"
 author: "Ben Alkov <ben.alkov@redhat.com>"
 description: "GitHub action for markdownlint."

--- a/shellcheck/action.yaml
+++ b/shellcheck/action.yaml
@@ -1,3 +1,4 @@
+---
 name: "shellcheck"
 author: "Ben Alkov <ben.alkov@redhat.com>"
 description: "GitHub action for ShellCheck."

--- a/tekton-lint/action.yaml
+++ b/tekton-lint/action.yaml
@@ -1,3 +1,4 @@
+---
 name: "tekton-lint"
 author: "Ben Alkov <ben.alkov@redhat.com>"
 description: "GitHub action for tekton-lint."

--- a/yamllint/Dockerfile
+++ b/yamllint/Dockerfile
@@ -1,0 +1,11 @@
+FROM registry.fedoraproject.org/fedora:35
+
+RUN dnf -y --nodocs  --setopt=install_weak_deps=False \
+--disablerepo=fedora-cisco-openh264 \
+--disablerepo=fedora-modular \
+--disablerepo=updates-modular \
+install yamllint && \
+dnf clean all
+
+ENTRYPOINT ["yamllint"]
+CMD ["-sf github"]

--- a/yamllint/README.md
+++ b/yamllint/README.md
@@ -1,0 +1,33 @@
+# 'yamllint' docker action
+
+A GitHub action to lint YAML files using [adrienverge/yamllint][].
+
+## Inputs
+
+### Paths to files to check, default config ('.') otherwise
+
+## Outputs
+
+### None
+
+## Example usages
+
+```yaml
+   uses: containerbuildsystem/actions/yamllint@master
+   with:
+     path: 'file.yml'
+```
+
+```yaml
+   uses: containerbuildsystem/actions/yamllint@master
+   with:
+     path: 'foo/'
+```
+
+```yaml
+   uses: containerbuildsystem/actions/yamllint@master
+   with:
+     path: 'foo/ bar/'
+```
+
+[adrienverge/yamllint]: https://github.com/adrienverge/yamllint

--- a/yamllint/action.yaml
+++ b/yamllint/action.yaml
@@ -1,0 +1,17 @@
+name: "yamllint for Py3"
+author: "Ben Alkov <ben.alkov@redhat.com>"
+description: "GitHub action for yamllint using Python 3."
+inputs:
+  path:
+    description: "Path containing YAML files to check. Can be a single file, wildcard, etc.
+                  '.' will automatcially find and check everything below $CWD."
+    required: true
+    default: '.'
+runs:
+  using: 'docker'
+  image: 'Dockerfile'
+  args:
+    - ${{ inputs.path }}
+branding:
+  icon: 'terminal'
+  color: 'red'

--- a/yamllint/action.yaml
+++ b/yamllint/action.yaml
@@ -1,10 +1,12 @@
+---
 name: "yamllint for Py3"
 author: "Ben Alkov <ben.alkov@redhat.com>"
 description: "GitHub action for yamllint using Python 3."
 inputs:
   path:
-    description: "Path containing YAML files to check. Can be a single file, wildcard, etc.
-                  '.' will automatcially find and check everything below $CWD."
+    description: "Path containing YAML files to check. Can be a single file,
+                  wildcard, etc.
+                  '.' will automatically find and check everything below $CWD."
     required: true
     default: '.'
 runs:


### PR DESCRIPTION
OOOH, this one's cool. It actually comments on the file diffs if it finds issues (as if it were doing a  review):

![image](https://user-images.githubusercontent.com/19691582/140385650-657675b4-6775-4cf8-9dd0-4cc65a53be8a.png)

✅  [Test run][] in my fork

Note that the shellcheck run in this PR will fail, as it still points at 'containerbuildsystem/actions@master'

Signed-off-by: Ben Alkov <ben.alkov@redhat.com>

[Test run]: https://github.com/ben-alkov/actions/runs/4107820840?check_suite_focus=true