### PR TITLE
Properly split doc8 args in Dockerfile

### DIFF
--- a/doc8/Dockerfile
+++ b/doc8/Dockerfile
@@ -8,4 +8,4 @@ install python3-pip python3-setuptools python3-wheel git && \
 dnf clean all && \
 pip3 --no-cache-dir install "doc8==0.9.1"
 
-ENTRYPOINT ["doc8", "--max-line-length 100"]
+ENTRYPOINT ["doc8", "--max-line-length", "100"]


### PR DESCRIPTION
Signed-off-by: Ben Alkov <ben.alkov@redhat.com>