### PR TITLE
Add pytype action

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,19 @@ Current collection
     - '--ignore-missing-imports'
   - inputs
     - 'package' parameter (required) (arg for '--package')
+- [pytype][]
+  - docker
+  - Fedora 34
+  - Py 3 < 3.10, Fedora default (3.9.x)
+  - pip
+    - pytype (latest)
+  - config
+    - defaults
+    - '-d import-error': ignore imports (pytype will fail (in GitHub workflows)
+      when checking for third party imports, unless they're explicitly
+      installed)
+  - inputs
+    - 'path' parameter (required), default '.'
 - [ShellCheck][]
   - docker
   - Fedora 35
@@ -97,6 +110,7 @@ Current collection
 [flake8]: ./flake8/README.md
 [markdownlint]: ./markdownlint/README.md
 [mypy]: ./mypy/README.md
+[pytype]: ./pytype/README.md
 [ShellCheck]: ./shellcheck/README.md
 [tekton-lint]: ./tekton-lint/README.md
 [yamllint]: ./yamllint/README.md

--- a/pytype/Dockerfile
+++ b/pytype/Dockerfile
@@ -1,0 +1,11 @@
+FROM registry.fedoraproject.org/fedora:34
+
+RUN dnf -y --nodocs  --setopt=install_weak_deps=False \
+--disablerepo=fedora-cisco-openh264 \
+--disablerepo=fedora-modular \
+--disablerepo=updates-modular \
+install python3-pip python3-setuptools python3-wheel python3-devel git gcc-c++ && \
+dnf clean all && \
+pip3 --no-cache-dir install pytype
+
+ENTRYPOINT ["pytype", "-d",  "import-error"]

--- a/pytype/README.md
+++ b/pytype/README.md
@@ -1,0 +1,22 @@
+# 'pytype' docker action
+
+A GitHub action to statically check Python types, using
+[google/pytype][].
+
+## Inputs
+
+### Path to Python sources to check
+
+## Outputs
+
+### None
+
+## Example usage
+
+```yaml
+   uses: containerbuildsystem/actions/pytype@master
+   with:
+     path: 'atomic_reactor'
+```
+
+[google/pytype]: https://github.com/google/pytype

--- a/pytype/action.yaml
+++ b/pytype/action.yaml
@@ -1,0 +1,17 @@
+---
+name: "pytype"
+author: "Ben Alkov <ben.alkov@redhat.com>"
+description: "GitHub action for pytype."
+inputs:
+  path:
+    description: 'Path to Python sources to check'
+    required: true
+    default: '.'
+runs:
+  using: 'docker'
+  image: 'Dockerfile'
+  args:
+    - ${{ inputs.path }}
+branding:
+  icon: 'terminal'
+  color: 'red'


### PR DESCRIPTION
Signed-off-by: Ben Alkov <ben.alkov@redhat.com>

:heavy_check_mark: Tested in my osbs-client fork's CI run #[4317506516][]

Note that F34 is *required*, as pytype doesn't yet support running on Python >= 3.10 (and I don't feel like figuring out modules... my last attempt was a frustrating disaster)

[4317506516]: https://github.com/ben-alkov/osbs-client/runs/4335688308?check_suite_focus=true