### PR TITLE
fix: mdl installation

### DIFF
--- a/markdownlint/Dockerfile
+++ b/markdownlint/Dockerfile
@@ -4,9 +4,9 @@ RUN dnf -y --nodocs  --setopt=install_weak_deps=False \
 --disablerepo=fedora-cisco-openh264 \
 --disablerepo=fedora-modular \
 --disablerepo=updates-modular \
-install ruby rubygems git && \
+install ruby ruby-devel gcc redhat-rpm-config rubygems git && \
 dnf clean all && \
-gem install mdl:'>=0.11.0'
+gem install mdl -v '>=0.13.0, <0.14'
 
 COPY action.sh /action/action.sh
 ENTRYPOINT ["bash", "/action/action.sh"]


### PR DESCRIPTION
New versions of mdl failed to install due the missing dependencies. Update dependencies and install only explicit minor version of mdl to prevent future issues.