### PR TITLE
Update tekton-lint

### DIFF
--- a/tekton-lint/Dockerfile
+++ b/tekton-lint/Dockerfile
@@ -1,11 +1,9 @@
-FROM registry.fedoraproject.org/fedora:35
+FROM registry.fedoraproject.org/fedora:41
 
 RUN dnf -y --nodocs  --setopt=install_weak_deps=False \
 --disablerepo=fedora-cisco-openh264 \
---disablerepo=fedora-modular \
---disablerepo=updates-modular \
 install nodejs npm && \
 dnf clean all && \
-npm install -g tekton-lint@v0.6.0
+npm install -g @ibm/tekton-lint@v1.0.0
 
 ENTRYPOINT ["tekton-lint"]


### PR DESCRIPTION
Tekton lint 1.0.0 was released (under IBM groupname)

Also use supported fedora version